### PR TITLE
[RFR] Refactor service injection to mogwais and gremlins

### DIFF
--- a/src/exceptions/loggerRequired.js
+++ b/src/exceptions/loggerRequired.js
@@ -1,0 +1,12 @@
+define(function(require) {
+    "use strict";
+
+    function LoggerRequiredException() {
+        this.message = 'This mogwai requires a logger to run. Please call logger(loggerObject) before executing the mogwai';
+        this.toString = function() {
+            return this.message;
+        };
+    }
+
+    return LoggerRequiredException;
+});

--- a/src/exceptions/randomizerRequired.js
+++ b/src/exceptions/randomizerRequired.js
@@ -1,0 +1,12 @@
+define(function(require) {
+    "use strict";
+
+    function RandomizerRequiredException() {
+        this.message = 'This gremlin requires a randomizer to run. Please call randomizer(randomizerObject) before executing the gremlin';
+        this.toString = function() {
+            return this.message;
+        };
+    }
+
+    return RandomizerRequiredException;
+});

--- a/src/main.js
+++ b/src/main.js
@@ -472,7 +472,7 @@ define(function(require) {
     function inject(services, objects) {
         for (var i = 0, count = objects.length; i < count; i++) {
             for (var name in services) {
-                if (typeof objects[i][name] === "function") {
+                if (typeof objects[i][name] === "function" && !objects[i][name]()) {
                     objects[i][name](services[name]);
                 }
             }

--- a/src/mogwais/alert.js
+++ b/src/mogwais/alert.js
@@ -29,22 +29,21 @@ define(function(require) {
 
     var configurable = require('../utils/configurable');
     var Chance = require('../vendor/chance');
+    var LoggerRequiredException = require('../exceptions/loggerRequired');
 
     return function() {
 
         var defaultWatchEvents = ['alert', 'confirm', 'prompt'];
 
-        var defaultConfirmResponse = function() {
+        function defaultConfirmResponse() {
             // Random OK or cancel
             return config.randomizer.bool();
-        };
+        }
 
-        var defaultPromptResponse = function() {
+        function defaultPromptResponse() {
             // Return a random string
             return config.randomizer.sentence();
-        };
-
-        var defaultLogger = { warn: function() {} };
+        }
 
         /**
          * @mixin
@@ -53,8 +52,8 @@ define(function(require) {
             watchEvents:     defaultWatchEvents,
             confirmResponse: defaultConfirmResponse,
             promptResponse:  defaultPromptResponse,
-            logger:          defaultLogger,
-            randomizer:      new Chance()
+            logger:          null,
+            randomizer:      null
         };
 
         var alert   = window.alert;
@@ -65,6 +64,11 @@ define(function(require) {
          * @mixes config
          */
         function alertMogwai() {
+
+            if (!config.logger) {
+                throw new LoggerRequiredException();
+            }
+
             if (config.watchEvents.indexOf('alert') !== -1) {
                 window.alert = function (msg) {
                     config.logger.warn('mogwai ', 'alert     ', msg, 'alert');

--- a/src/mogwais/fps.js
+++ b/src/mogwais/fps.js
@@ -30,20 +30,15 @@ define(function(require) {
     "use strict";
 
     var configurable = require('../utils/configurable');
+    var LoggerRequiredException = require('../exceptions/loggerRequired');
 
     return function() {
 
-        var defaultLogger = {
-            log: function() {},
-            warn: function() {},
-            error: function() {}
-        };
-
-        var defaultLevelSelector = function(fps) {
+        function defaultLevelSelector(fps) {
             if (fps < 10) return 'error';
             if (fps < 20) return 'warn';
             return 'log';
-        };
+        }
 
         /**
          * @mixin
@@ -51,7 +46,7 @@ define(function(require) {
         var config = {
             delay: 500, // how often should the fps be measured
             levelSelector: defaultLevelSelector,
-            logger: defaultLogger
+            logger: null
         };
 
         var initialTime = -Infinity; // force initial measure
@@ -84,6 +79,9 @@ define(function(require) {
          * @mixes config
          */
         function fpsMogwai() {
+            if (!config.logger) {
+                throw new LoggerRequiredException();
+            }
             enabled = true;
             window.requestAnimationFrame(loop);
         }

--- a/src/mogwais/gizmo.js
+++ b/src/mogwais/gizmo.js
@@ -26,14 +26,12 @@ define(function(require) {
 
     return function() {
 
-        var defaultLogger = { warn: function() {} };
-
         /**
          * @mixin
          */
         var config = {
             maxErrors: 10,
-            logger:    defaultLogger
+            logger:    null
         };
 
         var realOnError, realLoggerError;
@@ -44,10 +42,11 @@ define(function(require) {
         function gizmoMogwai() {
             var nbErrors = 0;
             var horde = this; // this is exceptional - don't use 'this' for mogwais in general
-            function incrementNbErrors(){
+            function incrementNbErrors() {
                 nbErrors++;
                 if (nbErrors == config.maxErrors) {
                     horde.stop();
+                    if (!config.logger) return;
                     window.setTimeout(function() {
                         // display the mogwai error after the caught error
                         config.logger.warn('mogwai ', 'gizmo     ', 'stopped test execution after ', config.maxErrors, 'errors');
@@ -62,17 +61,17 @@ define(function(require) {
                 return realOnError ? realOnError(message, url, linenumber) : false;
             };
 
-            // console (or logger) errors
-            realLoggerError = config.logger.error;
-            config.logger.error = function() {
+            // console errors
+            realLoggerError = console.error;
+            console.error = function() {
                 incrementNbErrors();
-                realLoggerError.apply(config.logger, arguments);
+                realLoggerError.apply(console, arguments);
             };
         }
 
         gizmoMogwai.cleanUp = function() {
             window.onerror = realOnError;
-            config.logger.error = realLoggerError.bind(config.logger);
+            console.error = realLoggerError.bind(console);
             return gizmoMogwai;
         };
 

--- a/src/species/clicker.js
+++ b/src/species/clicker.js
@@ -49,6 +49,7 @@ define(function(require) {
 
     var configurable = require('../utils/configurable');
     var Chance = require('../vendor/chance');
+    var RandomizerRequiredException = require('../exceptions/randomizerRequired');
 
     return function() {
 
@@ -57,14 +58,14 @@ define(function(require) {
 
         var defaultClickTypes = ['click', 'click', 'click', 'click', 'click', 'click', 'dblclick', 'dblclick', 'mousedown', 'mouseup', 'mouseover', 'mouseover', 'mouseover', 'mousemove', 'mouseout'];
 
-        var defaultPositionSelector = function() {
+        function defaultPositionSelector() {
             return [
                 config.randomizer.natural({ max: document.documentElement.clientWidth - 1 }),
                 config.randomizer.natural({ max: document.documentElement.clientHeight - 1 })
             ];
-        };
+        }
 
-        var defaultShowAction = function(x, y) {
+        function defaultShowAction(x, y) {
             var clickSignal = document.createElement('div');
             clickSignal.style.border = "3px solid red";
             clickSignal.style['border-radius'] = '50%'; // Chrome
@@ -85,9 +86,11 @@ define(function(require) {
             setTimeout(function() {
                 element.style.opacity = 0;
             }, 50);
-        };
+        }
 
-        var defaultCanClick = function() { return true; };
+        function defaultCanClick() {
+            return true;
+        }
 
         /**
          * @mixin
@@ -98,14 +101,17 @@ define(function(require) {
             showAction:       defaultShowAction,
             canClick:         defaultCanClick,
             maxNbTries:       10,
-            logger:           {},
-            randomizer:       new Chance()
+            logger:           null,
+            randomizer:       null
         };
 
         /**
          * @mixes config
          */
         function clickerGremlin() {
+            if (!config.randomizer) {
+                throw new RandomizerRequiredException();
+            }
             var position, posX, posY, targetElement, nbTries = 0;
             do {
                 position = config.positionSelector();
@@ -125,7 +131,7 @@ define(function(require) {
                 config.showAction(posX, posY, clickType);
             }
 
-            if (typeof config.logger.log == 'function') {
+            if (config.logger && typeof config.logger.log == 'function') {
                 config.logger.log('gremlin', 'clicker   ', clickType, 'at', posX, posY);
             }
         }

--- a/src/species/formFiller.js
+++ b/src/species/formFiller.js
@@ -24,6 +24,7 @@ define(function(require) {
 
     var configurable = require('../utils/configurable');
     var Chance = require('../vendor/chance');
+    var RandomizerRequiredException = require('../exceptions/randomizerRequired');
 
     return function() {
 
@@ -41,7 +42,7 @@ define(function(require) {
             'input:not([type])': fillTextElement
         };
 
-        var defaultShowAction = function(element) {
+        function defaultShowAction(element) {
             if(typeof element.attributes['data-old-border'] === 'undefined') {
                 element.attributes['data-old-border'] = element.style.border;
             }
@@ -52,9 +53,11 @@ define(function(require) {
             setTimeout(function() {
                 element.style.border = oldBorder;
             }, 500);
-        };
+        }
 
-        var defaultCanFillElement = function() { return true; };
+        function defaultCanFillElement() {
+            return true;
+        }
 
         /**
          * @mixin
@@ -64,18 +67,22 @@ define(function(require) {
             showAction:      defaultShowAction,
             canFillElement:  defaultCanFillElement,
             maxNbTries:      10,
-            logger:          {},
-            randomizer:      new Chance()
+            logger:          null,
+            randomizer:      null
         };
 
         /**
          * @mixes config
          */
         function formFillerGremlin() {
+            if (!config.randomizer) {
+                throw new RandomizerRequiredException();
+            }
+
             // Retrieve all selectors
             var elementTypes = [];
 
-            for(var key in config.elementMapTypes) {
+            for (var key in config.elementMapTypes) {
                 if(config.elementMapTypes.hasOwnProperty(key)) {
                     elementTypes.push(key);
                 }
@@ -107,7 +114,7 @@ define(function(require) {
                 config.showAction(element);
             }
 
-            if (typeof config.logger.log == 'function') {
+            if (config.logger && typeof config.logger.log == 'function') {
                 config.logger.log('gremlin', 'formFiller', 'input', value, 'in', element);
             }
         }

--- a/src/species/scroller.js
+++ b/src/species/scroller.js
@@ -30,6 +30,7 @@ define(function(require) {
 
     var configurable = require('../utils/configurable');
     var Chance = require('../vendor/chance');
+    var RandomizerRequiredException = require('../exceptions/randomizerRequired');
 
     return function() {
 
@@ -37,7 +38,7 @@ define(function(require) {
             documentElement = document.documentElement,
             body = document.body;
 
-        var defaultPositionSelector = function() {
+        function defaultPositionSelector() {
             var documentWidth = Math.max(body.scrollWidth, body.offsetWidth, documentElement.scrollWidth, documentElement.offsetWidth, documentElement.clientWidth),
                 documentHeight = Math.max(body.scrollHeight, body.offsetHeight, documentElement.scrollHeight, documentElement.offsetHeight, documentElement.clientHeight);
 
@@ -45,9 +46,9 @@ define(function(require) {
                 config.randomizer.natural({ max: documentWidth  - documentElement.clientWidth }),
                 config.randomizer.natural({ max: documentHeight  - documentElement.clientHeight })
             ];
-        };
+        }
 
-        var defaultShowAction = function(scrollX, scrollY) {
+        function defaultShowAction(scrollX, scrollY) {
             var clickSignal = document.createElement('div');
             clickSignal.style.border = "3px solid red";
             clickSignal.style.width = (documentElement.clientWidth - 25) + "px";
@@ -65,7 +66,7 @@ define(function(require) {
             setTimeout(function() {
                 element.style.opacity = 0;
             }, 50);
-        };
+        }
 
         /**
          * @mixin
@@ -73,14 +74,18 @@ define(function(require) {
         var config = {
             positionSelector: defaultPositionSelector,
             showAction:       defaultShowAction,
-            logger:           {},
-            randomizer:       new Chance()
+            logger:           null,
+            randomizer:       null
         };
 
         /**
          * @mixes config
          */
         function scrollerGremlin() {
+            if (!config.randomizer) {
+                throw new RandomizerRequiredException();
+            }
+
             var position = config.positionSelector(),
                 scrollX = position[0],
                 scrollY = position[1];

--- a/src/species/typer.js
+++ b/src/species/typer.js
@@ -23,6 +23,7 @@ define(function(require) {
 
     var configurable = require('../utils/configurable');
     var Chance = require('../vendor/chance');
+    var RandomizerRequiredException = require('../exceptions/randomizerRequired');
 
     return function() {
 
@@ -32,15 +33,15 @@ define(function(require) {
 
         var defaultEventTypes = ['keypress', 'keyup', 'keydown'];
 
-        var defaultKeyGenerator = function() {
-            return this.randomizer.natural({ max: 360});
-        };
+        function defaultKeyGenerator() {
+            return config.randomizer.natural({ max: 360});
+        }
 
-        var defaultTargetElement = function(x, y) {
+        function defaultTargetElement(x, y) {
             return document.elementFromPoint(x, y);
-        };
+        }
 
-        var defaultShowAction = function (targetElement, x, y, key) {
+        function defaultShowAction(targetElement, x, y, key) {
             var typeSignal = document.createElement('div');
             typeSignal.style.border = "3px solid orange";
             typeSignal.style['border-radius'] = '50%'; // Chrome
@@ -65,7 +66,7 @@ define(function(require) {
             setTimeout(function () {
                 element.style.opacity = 0;
             }, 50);
-        };
+        }
 
         /**
          * @mixin
@@ -75,14 +76,18 @@ define(function(require) {
             showAction: defaultShowAction,
             keyGenerator: defaultKeyGenerator,
             targetElement: defaultTargetElement,
-            logger:     {},
-            randomizer: new Chance()
+            logger:     null,
+            randomizer: null
         };
 
         /**
          * @mixes config
          */
         function typerGremlin() {
+            if (!config.randomizer) {
+                throw new RandomizerRequiredException();
+            }
+
             var keyboardEvent = document.createEventObject ? document.createEventObject() : document.createEvent("Events"),
                 eventType = config.randomizer.pick(config.eventTypes),
                 key = config.keyGenerator(),
@@ -104,7 +109,7 @@ define(function(require) {
                 config.showAction(targetElement, posX, posY, key);
             }
 
-            if (typeof config.logger.log == 'function') {
+            if (config.logger && typeof config.logger.log == 'function') {
                 config.logger.log('gremlin', 'typer       type', key, 'at', posX, posY);
             }
         }


### PR DESCRIPTION
- Gremlins and mogwais no longer have default logger and randomizer
- When a mogwai or a gremlin absolutely needs a service, and this service isn't present when it executes, it throws an appropriate exception
- The horde only injects logger and randomizer if not present (fixes #62)
- Anonymous function get a name everywhere as is simplifies debugging

The price to pay to fix #62 is that bundled gremlins are no longer self-sufficient.

Before:

``` js
// standalone usage
var clicker = gremlins.species.clicker();
clicker(); // works 
clicker.randomizer({ natural: function() { return 1; }); // works

// horde usage
var clicker = gremlins.species.clicker();
clicker.randomizer({ natural: function() { return 1; }); // does not work, overridden by horde!
horde.gremlin(clicker);
```

After:

``` js
// standalone usage
var clicker = gremlins.species.clicker();
clicker(); // doesn't work - exception thorwn requiring randomizer
clicker.randomizer(new Chance());
clicker(); // works 
clicker.randomizer({ natural: function() { return 1; }); // works

// horde usage
var clicker = gremlins.species.clicker();
clicker.randomizer({ natural: function() { return 1; }); // works, not overridden by horde
horde.gremlin(clicker);
```

However, as gremlins are used inside a horde 99% of the time, that's no big a deal.
