### PR TITLE
fix: add hmtl prototype for numbers elements

### DIFF
--- a/src/species/formFiller.js
+++ b/src/species/formFiller.js
@@ -41,7 +41,7 @@ const getDefaultConfig = (randomizer) => {
     const fillNumberElement = (element) => {
         const number = randomizer.character({ pool: '0123456789' });
         const newValue = element.value + number;
-        triggerSimulatedOnChange(element, newValue);
+        triggerSimulatedOnChange(element, newValue, window.HTMLInputElement.prototype);
 
         return number;
     };


### PR DESCRIPTION
Fix https://github.com/marmelab/gremlins.js/issues/162

**What**: Fix error when an input number is present on the page
**How**: Add the html prototype to trigger on change function
