### PR TITLE
feat: allow to pass a custom window to gremlins

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@
   - [Setting Up a Strategy](#setting-up-a-strategy)
   - [Stopping The Attack](#stopping-the-attack)
   - [Customizing The Logger](#customizing-the-logger)
+  - [Cypress](#cypress)
 - [Docs](#docs)
   - [Issues](#issues)
   - [🐛 Bugs](#-bugs)
@@ -299,6 +300,27 @@ const customLogger = {
     },
 };
 horde.createHorde({ logger: customLogger });
+```
+
+### Cypress
+
+To run gremlins.js inside a cypress test, you need to provide the tested window:
+
+```js
+import { createHorde } from 'gremlins.js';
+
+describe('Run gremlins.js inside a cypress test', () => {
+    let horde;
+    beforeEach(() =>
+        cy.window().then((testedWindow) => {
+            horde = createHorde({ window: testedWindow });
+        })
+    );
+    it('should run gremlins.js', async () => {
+        await horde.unleash();
+        /* ... */
+    });
+});
 ```
 
 ## Docs

--- a/src/index.js
+++ b/src/index.js
@@ -22,16 +22,26 @@ const defaultConfig = {
     strategies: [distribution()],
     logger: console,
     randomizer: new Chance(),
+    window: window,
 };
 
 export const createHorde = (userConfig) => {
     const config = { ...defaultConfig, ...userConfig };
-    const { logger, randomizer } = config;
+    const { logger, randomizer, window } = config;
 
-    const species = config.species.map((specie) => specie(logger, randomizer));
+    const speciesConfig = {
+        logger,
+        randomizer,
+        window,
+    };
+    const species = config.species.map((specie) => specie(speciesConfig));
     const strategies = config.strategies.map((strat) => strat(randomizer));
     const stop = () => strategies.forEach((strat) => strat.stop());
-    const mogwais = config.mogwais.map((mogwai) => mogwai(logger, randomizer, stop));
+    const mogwaisConfig = {
+        ...speciesConfig,
+        stop,
+    };
+    const mogwais = config.mogwais.map((mogwai) => mogwai(mogwaisConfig));
 
     const unleash = async () => {
         const beforeHorde = [...mogwais];

--- a/src/mogwais/alert.js
+++ b/src/mogwais/alert.js
@@ -16,7 +16,7 @@ const getDefaultConfig = (randomizer) => {
     };
 };
 
-export default (userConfig) => (logger, randomizer) => {
+export default (userConfig) => ({ logger, randomizer, window }) => {
     const config = { ...getDefaultConfig(randomizer), ...userConfig };
 
     const alert = window.alert;

--- a/src/mogwais/alert.spec.js
+++ b/src/mogwais/alert.spec.js
@@ -3,6 +3,7 @@ import alert from './alert';
 describe('alert', () => {
     const chanceBoolMock = jest.fn();
     const chanceSentenceMock = jest.fn();
+    let config;
     let consoleMock;
     let chanceMock;
 
@@ -12,10 +13,15 @@ describe('alert', () => {
             bool: chanceBoolMock,
             sentence: chanceSentenceMock,
         };
+        config = {
+            logger: consoleMock,
+            randomizer: chanceMock,
+            window,
+        };
     });
 
     it('should call logger warn when window.alert is call', () => {
-        const mogwais = alert()(consoleMock, chanceMock);
+        const mogwais = alert()(config);
 
         mogwais();
         window.alert('new alert');
@@ -25,7 +31,7 @@ describe('alert', () => {
     });
 
     it('should call logger warn when window.confirm is call', () => {
-        const mogwais = alert()(consoleMock, chanceMock);
+        const mogwais = alert()(config);
 
         mogwais();
         window.confirm('new confirm');
@@ -35,7 +41,7 @@ describe('alert', () => {
     });
 
     it('should call logger warn when window.prompt is call', () => {
-        const mogwais = alert()(consoleMock, chanceMock);
+        const mogwais = alert()(config);
 
         mogwais();
         window.prompt('new prompt');
@@ -45,7 +51,7 @@ describe('alert', () => {
     });
 
     it('should call randomize bool when window.confirm is call', () => {
-        const mogwais = alert()(consoleMock, chanceMock);
+        const mogwais = alert()(config);
 
         mogwais();
         window.confirm('new confirm');
@@ -54,7 +60,7 @@ describe('alert', () => {
     });
 
     it('should call randomize sentence when window.prompt is call', () => {
-        const mogwais = alert()(consoleMock, chanceMock);
+        const mogwais = alert()(config);
 
         mogwais();
         window.prompt('new prompt');
@@ -64,7 +70,7 @@ describe('alert', () => {
 
     it('should cleanup the window prop when cleanUp function is call', () => {
         jest.spyOn(window, 'alert').mockImplementation();
-        const mogwais = alert()(consoleMock, chanceMock);
+        const mogwais = alert()(config);
 
         mogwais();
         window.alert('new alert');
@@ -78,7 +84,7 @@ describe('alert', () => {
     });
 
     it('should not override the window object when logger is not defined ', () => {
-        const mogwais = alert()(null, chanceMock);
+        const mogwais = alert()(config);
 
         mogwais();
         window.alert('new alert');

--- a/src/mogwais/fps.js
+++ b/src/mogwais/fps.js
@@ -12,7 +12,7 @@ const getDefaultConfig = () => {
     };
 };
 
-export default (userConfig) => (logger) => {
+export default (userConfig) => ({ logger, window }) => {
     const config = { ...getDefaultConfig(), ...userConfig };
 
     let initialTime = -Infinity; // force initial measure

--- a/src/mogwais/fps.spec.js
+++ b/src/mogwais/fps.spec.js
@@ -2,6 +2,7 @@ import fps from './fps';
 
 describe('fps', () => {
     let consoleMock;
+    let config;
     let time;
 
     beforeEach(() => {
@@ -14,10 +15,14 @@ describe('fps', () => {
                 return cb(time);
             }
         });
+        config = {
+            logger: consoleMock,
+            window,
+        };
     });
 
     it('should log two times the fps mogwais', async () => {
-        const mogwais = fps()(consoleMock);
+        const mogwais = fps()(config);
 
         mogwais();
         mogwais.cleanUp();

--- a/src/mogwais/gizmo.js
+++ b/src/mogwais/gizmo.js
@@ -1,6 +1,6 @@
 const defaultConfig = { maxErrors: 10 };
 
-export default (userConfig) => (logger, _ignore, stop) => {
+export default (userConfig) => ({ logger, stop, window }) => {
     const config = { ...defaultConfig, ...userConfig };
 
     let realOnError;

--- a/src/mogwais/gizmo.spec.js
+++ b/src/mogwais/gizmo.spec.js
@@ -3,16 +3,24 @@ import gizmo from './gizmo';
 jest.useFakeTimers();
 
 describe('gizmo', () => {
+    let config;
+    let stopMock;
     let consoleErrorSpy;
     let windowErrorSpy = jest.fn();
 
     beforeEach(() => {
+        stopMock = jest.fn();
         consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
         window.onerror = windowErrorSpy;
+        config = {
+            logger: console,
+            stop: stopMock,
+            window,
+        };
     });
 
     it('should call console.error with right args', () => {
-        const mogwais = gizmo()(console);
+        const mogwais = gizmo()(config);
 
         mogwais();
 
@@ -23,7 +31,7 @@ describe('gizmo', () => {
     });
 
     it('should call window.error with right args', () => {
-        const mogwais = gizmo()(console);
+        const mogwais = gizmo()(config);
 
         mogwais();
 
@@ -34,8 +42,7 @@ describe('gizmo', () => {
     });
 
     it('should call stop when maxErrors is reached', () => {
-        const stop = jest.fn();
-        const mogwais = gizmo({ maxErrors: 2 })(console, null, stop);
+        const mogwais = gizmo({ maxErrors: 2 })(config);
 
         mogwais();
 
@@ -46,7 +53,7 @@ describe('gizmo', () => {
         expect(consoleErrorSpy).toHaveBeenNthCalledWith(1, 'first error');
         expect(consoleErrorSpy).toHaveBeenNthCalledWith(2, 'second', 'error');
 
-        expect(stop).toHaveBeenCalledTimes(1);
+        expect(stopMock).toHaveBeenCalledTimes(1);
 
         expect(setTimeout).toHaveBeenCalledTimes(1);
         expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 4);

--- a/src/species/clicker.js
+++ b/src/species/clicker.js
@@ -1,4 +1,4 @@
-const getDefaultConfig = (randomizer) => {
+const getDefaultConfig = (randomizer, window) => {
     const defaultClickTypes = [
         'click',
         'click',
@@ -68,9 +68,9 @@ const getDefaultConfig = (randomizer) => {
     };
 };
 
-export default (userConfig) => (logger, randomizer) => {
+export default (userConfig) => ({ logger, randomizer, window }) => {
     const config = {
-        ...getDefaultConfig(randomizer),
+        ...getDefaultConfig(randomizer, window),
         ...userConfig,
     };
 

--- a/src/species/clicker.spec.js
+++ b/src/species/clicker.spec.js
@@ -5,6 +5,7 @@ jest.useFakeTimers();
 describe('clicker', () => {
     const dispatchEventSpy = jest.fn();
     const initMouseEventSpy = jest.fn();
+    let config;
     let consoleMock;
     let chanceMock;
 
@@ -34,10 +35,15 @@ describe('clicker', () => {
             value: 11,
         });
         jest.spyOn(document, 'createEvent').mockImplementation(() => ({ initMouseEvent: initMouseEventSpy }));
+        config = {
+            logger: consoleMock,
+            randomizer: chanceMock,
+            window,
+        };
     });
 
     it('should log the cliker', () => {
-        const species = clicker({ log: true })(consoleMock, chanceMock);
+        const species = clicker({ log: true })(config);
 
         species();
 
@@ -46,7 +52,7 @@ describe('clicker', () => {
     });
 
     it("should click on element but don't show element", () => {
-        const species = clicker({ showAction: false })(consoleMock, chanceMock);
+        const species = clicker({ showAction: false })(config);
 
         species();
 
@@ -56,7 +62,7 @@ describe('clicker', () => {
 
     it("should try to click twice on element but can't click at the end", () => {
         const canClickSpy = jest.fn();
-        const species = clicker({ canClick: canClickSpy, maxNbTries: 2 })(consoleMock, chanceMock);
+        const species = clicker({ canClick: canClickSpy, maxNbTries: 2 })(config);
 
         species();
 
@@ -65,7 +71,7 @@ describe('clicker', () => {
     });
 
     it('should click on myid element and add new element', () => {
-        const species = clicker()(consoleMock, chanceMock);
+        const species = clicker()(config);
 
         species();
 

--- a/src/species/formFiller.js
+++ b/src/species/formFiller.js
@@ -1,4 +1,4 @@
-const getDefaultConfig = (randomizer) => {
+const getDefaultConfig = (randomizer, window) => {
     const document = window.document;
 
     /**
@@ -120,10 +120,10 @@ const getDefaultConfig = (randomizer) => {
     };
 };
 
-export default (userConfig) => (logger, randomizer) => {
+export default (userConfig) => ({ logger, randomizer, window }) => {
     const document = window.document;
 
-    const config = { ...getDefaultConfig(randomizer), ...userConfig };
+    const config = { ...getDefaultConfig(randomizer, window), ...userConfig };
 
     return () => {
         // Retrieve all selectors

--- a/src/species/formFiller.spec.js
+++ b/src/species/formFiller.spec.js
@@ -6,6 +6,7 @@ describe('formFiller', () => {
     let consoleMock;
     let inputText;
     let chanceMock;
+    let config;
 
     beforeEach(() => {
         consoleMock = { log: jest.fn() };
@@ -19,6 +20,11 @@ describe('formFiller', () => {
         inputText.setAttribute('type', 'text');
         inputText.setAttribute('id', 'myid');
         document.body.appendChild(inputText);
+        config = {
+            logger: consoleMock,
+            randomizer: chanceMock,
+            window,
+        };
     });
 
     afterEach(() => {
@@ -26,7 +32,7 @@ describe('formFiller', () => {
     });
 
     it('should log the formFiller', () => {
-        const species = formFiller({ log: true })(consoleMock, chanceMock);
+        const species = formFiller({ log: true })(config);
 
         species();
 
@@ -35,7 +41,7 @@ describe('formFiller', () => {
     });
 
     it("should fill element but don't show element", () => {
-        const species = formFiller({ showAction: false })(consoleMock, chanceMock);
+        const species = formFiller({ showAction: false })(config);
 
         species();
 
@@ -45,7 +51,7 @@ describe('formFiller', () => {
 
     it("should try to fill twice on element but can't fill at the end", () => {
         const canFillElementSpy = jest.fn();
-        const species = formFiller({ canFillElement: canFillElementSpy, maxNbTries: 2 })(consoleMock, chanceMock);
+        const species = formFiller({ canFillElement: canFillElementSpy, maxNbTries: 2 })(config);
 
         species();
 
@@ -54,7 +60,7 @@ describe('formFiller', () => {
     });
 
     it('should fill element and add new element', () => {
-        const species = formFiller()(consoleMock, chanceMock);
+        const species = formFiller()(config);
 
         species();
 

--- a/src/species/scroller.js
+++ b/src/species/scroller.js
@@ -1,4 +1,4 @@
-const getDefaultConfig = (randomizer) => {
+const getDefaultConfig = (randomizer, window) => {
     const document = window.document;
     const documentElement = document.documentElement;
     const body = document.body;
@@ -59,8 +59,8 @@ const getDefaultConfig = (randomizer) => {
     };
 };
 
-export default (userConfig) => (logger, randomizer) => {
-    const config = { ...getDefaultConfig(randomizer), ...userConfig };
+export default (userConfig) => ({ logger, randomizer, window }) => {
+    const config = { ...getDefaultConfig(randomizer, window), ...userConfig };
     return () => {
         const position = config.positionSelector();
         const scrollX = position[0];

--- a/src/species/scroller.spec.js
+++ b/src/species/scroller.spec.js
@@ -5,6 +5,7 @@ jest.useFakeTimers();
 describe('scroller', () => {
     let consoleMock;
     let chanceMock;
+    let config;
 
     const scrollToSpy = jest.fn();
 
@@ -27,10 +28,15 @@ describe('scroller', () => {
                 value: documentElementProps[key],
             });
         });
+        config = {
+            logger: consoleMock,
+            randomizer: chanceMock,
+            window,
+        };
     });
 
     it('should log the scroller', () => {
-        const species = scroller({ log: true })(consoleMock, chanceMock);
+        const species = scroller({ log: true })(config);
 
         species();
 
@@ -39,7 +45,7 @@ describe('scroller', () => {
     });
 
     it("should scroll but don't show element", () => {
-        const species = scroller({ showAction: false })(consoleMock, chanceMock);
+        const species = scroller({ showAction: false })(config);
 
         species();
 
@@ -49,7 +55,7 @@ describe('scroller', () => {
     });
 
     it('should scroll and add new element', () => {
-        const species = scroller()(consoleMock, chanceMock);
+        const species = scroller()(config);
 
         species();
 

--- a/src/species/toucher.js
+++ b/src/species/toucher.js
@@ -1,4 +1,4 @@
-const getDefaultConfig = (randomizer) => {
+const getDefaultConfig = (randomizer, window) => {
     const document = window.document;
     const body = document.body;
 
@@ -68,9 +68,9 @@ const getDefaultConfig = (randomizer) => {
     };
 };
 
-export default (userConfig) => (logger, randomizer) => {
+export default (userConfig) => ({ logger, randomizer, window }) => {
     const document = window.document;
-    const config = { ...getDefaultConfig(randomizer), ...userConfig };
+    const config = { ...getDefaultConfig(randomizer, window), ...userConfig };
 
     const getTouches = (center, points, radius, degrees) => {
         const cx = center[0];

--- a/src/species/toucher.spec.js
+++ b/src/species/toucher.spec.js
@@ -3,6 +3,7 @@ import toucher from './toucher';
 describe('toucher', () => {
     const dispatchEventSpy = jest.fn();
     const initEventSpy = jest.fn();
+    let config;
     let inputText;
     let chanceMock;
     let consoleMock;
@@ -40,6 +41,12 @@ describe('toucher', () => {
         jest.spyOn(document, 'createEvent').mockImplementation(() => ({ initEvent: initEventSpy }));
 
         jest.useFakeTimers();
+
+        config = {
+            logger: consoleMock,
+            randomizer: chanceMock,
+            window,
+        };
     });
 
     afterEach(() => {
@@ -47,7 +54,7 @@ describe('toucher', () => {
     });
 
     it('should log the toucher', () => {
-        const species = toucher({ log: true })(consoleMock, chanceMock);
+        const species = toucher({ log: true })(config);
 
         species();
         jest.runAllTimers();
@@ -56,7 +63,7 @@ describe('toucher', () => {
     });
 
     it("should touch the element but don't show element", () => {
-        const species = toucher({ showAction: false })(console, chanceMock);
+        const species = toucher({ showAction: false })(config);
 
         species();
 
@@ -65,7 +72,7 @@ describe('toucher', () => {
     });
 
     it('should touch on myid element and add new element', () => {
-        const species = toucher()(console, chanceMock);
+        const species = toucher()(config);
 
         species();
 

--- a/src/species/typer.js
+++ b/src/species/typer.js
@@ -1,4 +1,4 @@
-const getDefaultConfig = (randomizer) => {
+const getDefaultConfig = (randomizer, window) => {
     const document = window.document;
     const body = document.body;
 
@@ -49,10 +49,10 @@ const getDefaultConfig = (randomizer) => {
     };
 };
 
-export default (userConfig) => (logger, randomizer) => {
+export default (userConfig) => ({ logger, randomizer, window }) => {
     const document = window.document;
     const documentElement = document.documentElement;
-    const config = { ...getDefaultConfig(randomizer), ...userConfig };
+    const config = { ...getDefaultConfig(randomizer, window), ...userConfig };
 
     return () => {
         const keyboardEvent = document.createEventObject

--- a/src/species/typer.spec.js
+++ b/src/species/typer.spec.js
@@ -5,13 +5,13 @@ jest.useFakeTimers();
 describe('typer', () => {
     const dispatchEventSpy = jest.fn();
     const initMouseEventSpy = jest.fn();
-    let console;
+    let consoleMock;
     let inputText;
-    let chance;
-
+    let chanceMock;
+    let config;
     beforeEach(() => {
-        console = { log: jest.fn() };
-        chance = {
+        consoleMock = { log: jest.fn() };
+        chanceMock = {
             natural: ({ min, max }) => (min ? 65 : max), // 65 = a
             pick: (types) => types[0],
         };
@@ -38,6 +38,12 @@ describe('typer', () => {
             value: 11,
         });
         jest.spyOn(document, 'createEvent').mockImplementation(() => ({ initMouseEvent: initMouseEventSpy }));
+
+        config = {
+            logger: consoleMock,
+            randomizer: chanceMock,
+            window,
+        };
     });
 
     afterEach(() => {
@@ -45,16 +51,16 @@ describe('typer', () => {
     });
 
     it('should log the typer', () => {
-        const species = typer({ log: true })(console, chance);
+        const species = typer({ log: true })(config);
 
         species();
 
-        expect(console.log).toHaveBeenCalledTimes(1);
-        expect(console.log).toHaveBeenCalledWith('gremlin', 'typer type', 'A', 'at', 10, 10);
+        expect(consoleMock.log).toHaveBeenCalledTimes(1);
+        expect(consoleMock.log).toHaveBeenCalledWith('gremlin', 'typer type', 'A', 'at', 10, 10);
     });
 
     it("should type on element but don't show element", () => {
-        const species = typer({ showAction: false })(console, chance);
+        const species = typer({ showAction: false })(config);
 
         species();
 
@@ -69,7 +75,7 @@ describe('typer', () => {
     });
 
     it('should type on myid element and add new element', () => {
-        const species = typer()(console, chance);
+        const species = typer()(config);
 
         species();
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Allow a custom window to be pass to `createHorde`.

<!-- Why are these changes necessary? -->

**Why**: This change is necessary to run gremlins.js with cypress as we want to pass the tested window to gremlins and not cypress' window.

<!-- How were these changes implemented? -->

**How**: Using the existing config passed to createHorde, you can now pass a window like a logger or a randomizer.

<!-- Have you done all of these things?  -->

**Checklist**:

-   [x] Get window from config
-   [x] Set default to current window to keep existing behavior
-   [x] Update mogwais & species to use config's window
-   [x] Update Tests
-   [x] Update Readme

<!-- feel free to add additional comments -->

Fix https://github.com/marmelab/gremlins.js/issues/165
