### PR TITLE
fix: clicker gremlin in Cypress

### DIFF
--- a/src/species/clicker.js
+++ b/src/species/clicker.js
@@ -1,4 +1,7 @@
 const getDefaultConfig = (randomizer, window) => {
+    const document = window.document;
+    const body = document.body;
+
     const defaultClickTypes = [
         'click',
         'click',
@@ -20,17 +23,15 @@ const getDefaultConfig = (randomizer, window) => {
     const defaultPositionSelector = () => {
         return [
             randomizer.natural({
-                max: Math.max(0, window.document.documentElement.clientWidth - 1),
+                max: Math.max(0, document.documentElement.clientWidth - 1),
             }),
             randomizer.natural({
-                max: Math.max(0, window.document.documentElement.clientHeight - 1),
+                max: Math.max(0, document.documentElement.clientHeight - 1),
             }),
         ];
     };
 
     const defaultShowAction = (x, y) => {
-        const document = window.document;
-        const body = document.body;
         const clickSignal = document.createElement('div');
         clickSignal.style.zIndex = 2000;
         clickSignal.style.border = '3px solid red';
@@ -69,6 +70,7 @@ const getDefaultConfig = (randomizer, window) => {
 };
 
 export default (userConfig) => ({ logger, randomizer, window }) => {
+    const document = window.document;
     const config = {
         ...getDefaultConfig(randomizer, window),
         ...userConfig,
@@ -85,12 +87,12 @@ export default (userConfig) => ({ logger, randomizer, window }) => {
             position = config.positionSelector();
             posX = position[0];
             posY = position[1];
-            targetElement = window.document.elementFromPoint(posX, posY);
+            targetElement = document.elementFromPoint(posX, posY);
             nbTries++;
             if (nbTries > config.maxNbTries) return;
         } while (!targetElement || !config.canClick(targetElement));
 
-        const evt = window.document.createEvent('MouseEvents');
+        const evt = document.createEvent('MouseEvents');
         const clickType = randomizer.pick(config.clickTypes);
         // todo remove deprecated https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/initMouseEvent
         evt.initMouseEvent(clickType, true, true, window, 0, 0, 0, posX, posY, false, false, false, false, 0, null);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
The clicker gremlin did not work in Cypress. There were no log and no visual clicks.
<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

**How**:
By using the same logic as the `toucher`: using the passed in window to define the document and the body when called.
My guess is that `window` is something else when the functions get called?
<!-- Have you done all of these things?  -->

**Checklist**:

-   [ ] Documentation added to the README.md file
-   [ ] Tests
-   [ ] Typescript definitions updated
-   [ ] RFR, Ready for review label

<!-- feel free to add additional comments -->
