### PR TITLE
feat: consider scrollTop when showing click action

### DIFF
--- a/src/species/clicker.js
+++ b/src/species/clicker.js
@@ -46,7 +46,7 @@ const getDefaultConfig = (randomizer, window) => {
         clickSignal.style.mozTransition = 'opacity 1s ease-out';
         clickSignal.style.transition = 'opacity 1s ease-out';
         clickSignal.style.left = x - 20 + 'px';
-        clickSignal.style.top = y - 20 + 'px';
+        clickSignal.style.top = y + document.documentElement.scrollTop - 20 + 'px';
         const element = body.appendChild(clickSignal);
         setTimeout(() => {
             body.removeChild(element);


### PR DESCRIPTION
**What**: feature, maybe bug


**Why**: when use `clicker` with `scroller`, `clicker`'s default `showAction` draw red circles without considering `window.scrollY`, which may bring confusion.

**How**: add `document.documentElement.scrollTop` (`window.scrollY`'s compatible version)

**Checklist**:

-   [x] Documentation added to the README.md file
-   [x] Tests, not applicble
-   [x] Typescript definitions updated
-   [x] RFR, Ready for review label

<!-- feel free to add additional comments -->
